### PR TITLE
Fix TypeError "expected bytes or bytearray, but got 'str'" with python3

### DIFF
--- a/local/handler/GithubHandler.py
+++ b/local/handler/GithubHandler.py
@@ -123,7 +123,7 @@ class GithubHandler(http.server.BaseHTTPRequestHandler):
                 s.wfile.write("This channel requires a secret\n".encode())
                 return
 
-            digest = "sha1=%s" % (hmac.new(secret, payload, hashlib.sha1).hexdigest(),)
+            digest = "sha1=%s" % (hmac.new(bytes(secret, 'utf-8'), bytes(payload, 'utf-8'), hashlib.sha1).hexdigest())
             log.debug("expected digest: %s", digest)
 
             provided = s.headers['X-Hub-Signature']


### PR DESCRIPTION
Fix
```
 File "[..]/plugins/Github/local/handler/GithubHandler.py", line 126, in do_POST
  File "/usr/lib64/python3.7/hmac.py", line 153, in new
    return HMAC(key, msg, digestmod)
  File "/usr/lib64/python3.7/hmac.py", line 49, in __init__
    raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
```
occurring when running the `supybot-github` plugin in python 3.7.9.

Signed-off-by: DLange of Faster IT GmbH